### PR TITLE
impl BlockDevice for std::fs::File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.bochsrc
+target
+**/*.rs.bk
+Cargo.lock
+.idea
+.gdbinit
+.gdb_history
+/CMakeLists.txt
+/*.iml
+/cmake-build-debug

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,8 +16,8 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.1.13"
-source = "git+https://github.com/Orycterope/lru-rs?branch=no_std#d2353339771b69256c6e0b5e219fb5ce51cd27c3"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -31,11 +31,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "storage_device"
 version = "1.0.0"
 dependencies = [
- "lru 0.1.13 (git+https://github.com/Orycterope/lru-rs?branch=no_std)",
+ "lru 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
-"checksum lru 0.1.13 (git+https://github.com/Orycterope/lru-rs?branch=no_std)" = "<none>"
+"checksum lru 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "276235bb6b60773280b44b65e93815de82da5b6279ef175004fca03f4d06770a"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,16 +28,10 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "spin"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "storage_device"
 version = "1.0.0"
 dependencies = [
  "lru 0.1.13 (git+https://github.com/Orycterope/lru-rs?branch=no_std)",
- "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
@@ -45,4 +39,3 @@ dependencies = [
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum lru 0.1.13 (git+https://github.com/Orycterope/lru-rs?branch=no_std)" = "<none>"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
-"checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ features = ["cached-block-device"]
 
 [dependencies]
 lru = { git = "https://github.com/Orycterope/lru-rs", branch = "no_std", features = ["nightly"], optional = true }
-spin = { version = "0.5.0", optional = true }
 
 [features]
-cached-block-device = ["lru", "spin"]
+cached-block-device = ["lru"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,20 @@ edition = "2018"
 features = ["cached-block-device"]
 
 [dependencies]
-lru = { git = "https://github.com/Orycterope/lru-rs", branch = "no_std", features = ["nightly"], optional = true }
+lru = { version = "0.1.15", optional = true }
 
 [features]
-cached-block-device = ["lru"]
+default = ["std"]
+# Link with std.
+# This feature adds implementation of BlockDevice for std::fs::File.
+#
+# Usually used for testing.
+std = []
+# This feature adds the CachedBlockDevice wrapper around any BlockDevice.
+# Uses the `lru` crate to manage its cache.
+#
+# Implies feature `std`.
+cached-block-device = ["std", "lru"]
+# Mutually exclusive with the `std` feature, as this would require to disable "lru/nightly" when built with std,
+# but cargo does not provide any way to do conditionnal feature definitions.
+cached-block-device-nightly = ["lru/nightly"]

--- a/src/block.rs
+++ b/src/block.rs
@@ -107,7 +107,7 @@ pub trait BlockDevice: Sized {
 /// flushing, or when they are evicted from the cache.
 ///
 /// When a CachedBlockDevice is dropped, it flushes its cache.
-#[cfg(feature = "cached-block-device")]
+#[cfg(any(feature = "cached-block-device", feature = "cached-block-device-nightly"))]
 pub struct CachedBlockDevice<B: BlockDevice> {
     /// The inner block device.
     block_device: B,
@@ -117,7 +117,7 @@ pub struct CachedBlockDevice<B: BlockDevice> {
 }
 
 /// Represent a cached block in the LRU cache.
-#[cfg(feature = "cached-block-device")]
+#[cfg(any(feature = "cached-block-device", feature = "cached-block-device-nightly"))]
 struct CachedBlock {
     /// Bool indicating whether this block should be written to device when flushing.
     dirty: bool,
@@ -125,7 +125,7 @@ struct CachedBlock {
     data: Block,
 }
 
-#[cfg(feature = "cached-block-device")]
+#[cfg(any(feature = "cached-block-device", feature = "cached-block-device-nightly"))]
 impl<B: BlockDevice> CachedBlockDevice<B> {
     /// Creates a new CachedBlockDevice that wraps `device`, and can hold at most `cap` blocks in cache.
     pub fn new(device: B, cap: usize) -> CachedBlockDevice<B> {
@@ -153,7 +153,7 @@ impl<B: BlockDevice> CachedBlockDevice<B> {
     }
 }
 
-#[cfg(feature = "cached-block-device")]
+#[cfg(any(feature = "cached-block-device", feature = "cached-block-device-nightly"))]
 impl<B: BlockDevice> Drop for CachedBlockDevice<B> {
     /// Dropping a CachedBlockDevice flushes it.
     ///
@@ -163,7 +163,7 @@ impl<B: BlockDevice> Drop for CachedBlockDevice<B> {
     }
 }
 
-#[cfg(feature = "cached-block-device")]
+#[cfg(any(feature = "cached-block-device", feature = "cached-block-device-nightly"))]
 impl<B: BlockDevice> BlockDevice for CachedBlockDevice<B> {
     /// Attempts to fill `blocks` with blocks found in the cache, and will fetch them from device if it can't.
     ///
@@ -276,7 +276,7 @@ impl<B: BlockDevice> BlockDevice for CachedBlockDevice<B> {
     }
 }
 
-#[cfg(test)]
+#[cfg(feature = "std")]
 impl BlockDevice for std::fs::File {
 
     /// Seeks to the appropriate position, and reads block by block.

--- a/src/block.rs
+++ b/src/block.rs
@@ -271,7 +271,7 @@ impl<B: BlockDevice> BlockDevice for CachedBlockDevice<B> {
         Ok(())
     }
 
-    fn count(&self) -> BlockResult<BlockCount> {
+    fn count(&mut self) -> BlockResult<BlockCount> {
         self.block_device.count()
     }
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -98,7 +98,7 @@ pub trait BlockDevice: Sized {
     fn write(&mut self, blocks: &[Block], index: BlockIndex) -> BlockResult<()>;
 
     /// Return the amount of blocks hold by the block device.
-    fn count(&self) -> BlockResult<BlockCount>;
+    fn count(&mut self) -> BlockResult<BlockCount>;
 }
 
 /// A BlockDevice that reduces device accesses by keeping the most recently used blocks in a cache.
@@ -305,7 +305,7 @@ impl BlockDevice for std::fs::File {
         Ok(())
     }
 
-    fn count(&self) -> BlockResult<BlockCount> {
+    fn count(&mut self) -> BlockResult<BlockCount> {
         let num_blocks = self.metadata()
             .map_err(|_| BlockError::Unknown)?
             .len() / (Block::LEN_U64);
@@ -341,7 +341,7 @@ impl StorageDevice for std::fs::File {
     }
 
     /// Return the total size of the storage device.
-    fn len(&self) -> StorageDeviceResult<u64> {
+    fn len(&mut self) -> StorageDeviceResult<u64> {
         Ok(
             self.metadata()
                 .map_err(|_| StorageDeviceError::Unknown)?

--- a/src/block.rs
+++ b/src/block.rs
@@ -349,3 +349,37 @@ impl StorageDevice for std::fs::File {
         )
     }
 }
+
+#[cfg(feature = "std")]
+impl StorageDevice for &std::fs::File {
+    /// Read the data at the given ``offset`` in the storage device into a given buffer.
+    fn read(&mut self, offset: u64, buf: &mut [u8]) -> StorageDeviceResult<()> {
+        use std::io::{Read, Seek};
+
+        self.seek(std::io::SeekFrom::Start(offset))
+            .map_err(|_| BlockError::ReadError)?;
+        self.read_exact(buf)
+            .map_err(|_| BlockError::ReadError)?;
+        Ok(())
+    }
+
+    /// Write the data from the given buffer at the given ``offset`` in the storage device.
+    fn write(&mut self, offset: u64, buf: &[u8]) -> StorageDeviceResult<()> {
+        use std::io::{Write, Seek};
+
+        self.seek(std::io::SeekFrom::Start(offset))
+            .map_err(|_| BlockError::WriteError)?;
+        self.write_all(buf)
+            .map_err(|_| BlockError::WriteError)?;
+        Ok(())
+    }
+
+    /// Return the total size of the storage device.
+    fn len(&mut self) -> StorageDeviceResult<u64> {
+        Ok(
+            self.metadata()
+                .map_err(|_| StorageDeviceError::Unknown)?
+                .len()
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub trait StorageDevice {
     /// Write the data from the given buffer at the given ``offset`` in the storage device.
     fn write(&mut self, offset: u64, buf: &[u8]) -> StorageDeviceResult<()>;
 
-    /// Return the total size of the storage device.
+    /// Return the total size of the storage device in bytes.
     fn len(&self) -> StorageDeviceResult<u64>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![no_std]
 
-#[cfg(test)]
+#[cfg(feature = "std")]
 extern crate std;
 
 /// Block device representation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub trait StorageDevice {
     fn write(&mut self, offset: u64, buf: &[u8]) -> StorageDeviceResult<()>;
 
     /// Return the total size of the storage device in bytes.
-    fn len(&self) -> StorageDeviceResult<u64>;
+    fn len(&mut self) -> StorageDeviceResult<u64>;
 }
 
 impl From<BlockError> for StorageDeviceError {
@@ -149,7 +149,7 @@ impl<B: BlockDevice> StorageDevice for StorageBlockDevice<B> {
         Ok(())
     }
 
-    fn len(&self) -> StorageDeviceResult<u64> {
+    fn len(&mut self) -> StorageDeviceResult<u64> {
         Ok(self.block_device.count()?.into_bytes_count())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 
 #![no_std]
 
+#[cfg(test)]
+extern crate std;
+
 /// Block device representation.
 pub mod block;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,10 @@ pub type StorageDeviceResult<T> = core::result::Result<T, StorageDeviceError>;
 #[allow(clippy::len_without_is_empty)]
 pub trait StorageDevice {
     /// Read the data at the given ``offset`` in the storage device into a given buffer.
-    fn read(&self, offset: u64, buf: &mut [u8]) -> StorageDeviceResult<()>;
+    fn read(&mut self, offset: u64, buf: &mut [u8]) -> StorageDeviceResult<()>;
 
     /// Write the data from the given buffer at the given ``offset`` in the storage device.
-    fn write(&self, offset: u64, buf: &[u8]) -> StorageDeviceResult<()>;
+    fn write(&mut self, offset: u64, buf: &[u8]) -> StorageDeviceResult<()>;
 
     /// Return the total size of the storage device.
     fn len(&self) -> StorageDeviceResult<u64>;
@@ -64,7 +64,7 @@ impl<B: BlockDevice> StorageBlockDevice<B> {
 }
 
 impl<B: BlockDevice> StorageDevice for StorageBlockDevice<B> {
-    fn read(&self, offset: u64, buf: &mut [u8]) -> StorageDeviceResult<()> {
+    fn read(&mut self, offset: u64, buf: &mut [u8]) -> StorageDeviceResult<()> {
         let mut read_size = 0u64;
         let mut blocks = [Block::new()];
 
@@ -103,7 +103,7 @@ impl<B: BlockDevice> StorageDevice for StorageBlockDevice<B> {
         Ok(())
     }
 
-    fn write(&self, offset: u64, buf: &[u8]) -> StorageDeviceResult<()> {
+    fn write(&mut self, offset: u64, buf: &[u8]) -> StorageDeviceResult<()> {
         let mut write_size = 0u64;
         let mut blocks = [Block::new()];
 


### PR DESCRIPTION
This was already done in libfat for RefCell\<File\>, but I needed it too for unit tests (and so will every user of BlockDevice), so I copy pasted it, and removed the need for RefCell by having BlockDevice take `&mut self`.

See commit descriptions