### PR TITLE
Remove extraneous Sized on BlockDevice

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -90,7 +90,7 @@ impl BlockCount {
 }
 
 /// Represent a device holding blocks.
-pub trait BlockDevice: Sized {
+pub trait BlockDevice {
     /// Read blocks from the block device starting at the given ``index``.
     fn read(&mut self, blocks: &mut [Block], index: BlockIndex) -> BlockResult<()>;
 


### PR DESCRIPTION
This dependency isn't needed and cause issues when trying to Box.