### PR TITLE
Make the block struct repr C and align to 512 bytes

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -16,6 +16,7 @@ pub type BlockResult<T> = core::result::Result<T, BlockError>;
 
 /// Represent a certain amount of data from a block device.
 #[derive(Clone)]
+#[repr(C, align(512))]
 pub struct Block {
     /// The actual storage of the block.
     pub contents: [u8; Block::LEN],


### PR DESCRIPTION
For easier interactions with blocks and hardware.