### PR TITLE
Make BlockDevice generic on the block size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "scopeguard"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,10 +37,12 @@ name = "storage_device"
 version = "1.0.0"
 dependencies = [
  "lru 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum lru 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "276235bb6b60773280b44b65e93815de82da5b6279ef175004fca03f4d06770a"
+"checksum plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ features = ["cached-block-device"]
 
 [dependencies]
 lru = { version = "0.1.15", optional = true }
+plain = { version = "0.2.3" }
 
 [features]
 default = ["std"]

--- a/src/block.rs
+++ b/src/block.rs
@@ -113,7 +113,7 @@ pub trait BlockDevice: core::fmt::Debug {
     /// use std::ops::{Deref, DerefMut};
     ///
     /// #[repr(C, align(2))]
-    /// #[derive(Debug, Clone, Copy)]
+    /// #[derive(Clone, Copy)]
     /// struct AhciBlock([u8; 512]);
     ///
     /// // Safety: Safe because AhciBlock is just a Repr(c) wrapper around a
@@ -299,7 +299,7 @@ impl<B: BlockDevice> BlockDevice for CachedBlockDevice<B> {
                     // fully_cached: block[i] is uninitialized, copy it from cache.
                     // dirty:        block[i] is initialized from device if !fully_cached,
                     //               but we hold a newer dirty version in cache, overlay it.
-                    *block = cached_block.data.clone();
+                    *block = cached_block.data;
                 }
             } else {
                 // add the block we just read to the cache.
@@ -313,7 +313,7 @@ impl<B: BlockDevice> BlockDevice for CachedBlockDevice<B> {
                 }
                 let new_cached_block = CachedBlock {
                     dirty: false,
-                    data: block.clone(),
+                    data: *block,
                 };
                 self.lru_cache
                     .put(BlockIndex(index.0 + i as u64), new_cached_block);
@@ -333,7 +333,7 @@ impl<B: BlockDevice> BlockDevice for CachedBlockDevice<B> {
             for (i, block) in blocks.iter().enumerate() {
                 let new_block = CachedBlock {
                     dirty: true,
-                    data: block.clone(),
+                    data: *block,
                 };
                 // add it to the cache
                 // if cache is full, flush its lru entry
@@ -367,7 +367,7 @@ impl<B: BlockDevice> BlockDevice for CachedBlockDevice<B> {
                     BlockIndex(index.0 + i as u64),
                     CachedBlock {
                         dirty: false,
-                        data: block.clone(),
+                        data: *block,
                     },
                 )
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ impl<B: BlockDevice> StorageBlockDevice<B> {
 impl<B: BlockDevice> StorageDevice for StorageBlockDevice<B> {
     fn read(&mut self, offset: u64, buf: &mut [u8]) -> StorageDeviceResult<()> {
         let mut read_size = 0u64;
-        let mut blocks = [Block::new()];
+        let mut blocks = [B::Block::default()];
 
         while read_size < buf.len() as u64 {
             // Compute the next offset of the data to read.
@@ -84,7 +84,7 @@ impl<B: BlockDevice> StorageDevice for StorageBlockDevice<B> {
 
             // Read the block.
             self.block_device
-                .read(&mut blocks, BlockIndex(current_block_index.0))?;
+                .read(&mut blocks[..], BlockIndex(current_block_index.0))?;
 
             // Slice on the part of the buffer we need.
             let buf_slice = &mut buf[read_size as usize..];
@@ -110,7 +110,7 @@ impl<B: BlockDevice> StorageDevice for StorageBlockDevice<B> {
 
     fn write(&mut self, offset: u64, buf: &[u8]) -> StorageDeviceResult<()> {
         let mut write_size = 0u64;
-        let mut blocks = [Block::new()];
+        let mut blocks = [B::Block::default()];
 
         while write_size < buf.len() as u64 {
             // Compute the next offset of the data to write.


### PR DESCRIPTION
There's something somewhat annoying with this design: It still does not allow blocks to have a *runtime* length. But it's still a lot better.