### PR TITLE
impl StorageDevice for Box<impl StorageDevice>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,16 @@ default = ["std"]
 # This feature adds implementation of BlockDevice for std::fs::File.
 #
 # Usually used for testing.
-std = []
+std = ["alloc"]
+# Link with alloc.
+# Activating this feature requires setting a global_allocator (unless used with
+# std). It allows using the StorageDevice trait with Box<T>.
+alloc = []
 # This feature adds the CachedBlockDevice wrapper around any BlockDevice.
 # Uses the `lru` crate to manage its cache.
 #
 # Implies feature `std`.
-cached-block-device = ["std", "lru"]
+cached-block-device = ["alloc", "lru"]
 # Mutually exclusive with the `std` feature, as this would require to disable "lru/nightly" when built with std,
 # but cargo does not provide any way to do conditionnal feature definitions.
 cached-block-device-nightly = ["lru/nightly"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,11 @@
 
 #[cfg(feature = "std")]
 extern crate std;
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
 
 /// Block device representation.
 pub mod block;
@@ -39,6 +44,20 @@ pub trait StorageDevice: core::fmt::Debug {
 
     /// Return the total size of the storage device in bytes.
     fn len(&mut self) -> StorageDeviceResult<u64>;
+}
+
+#[cfg(feature = "alloc")]
+impl<S: StorageDevice + ?Sized> StorageDevice for Box<S> {
+    fn read(&mut self, offset: u64, buf: &mut [u8]) -> StorageDeviceResult<()> {
+        (**self).read(offset, buf)
+    }
+    fn write(&mut self, offset: u64, buf: &[u8]) -> StorageDeviceResult<()> {
+        (**self).write(offset, buf)
+    }
+
+    fn len(&mut self) -> StorageDeviceResult<u64> {
+        (**self).len()
+    }
 }
 
 impl From<BlockError> for StorageDeviceError {


### PR DESCRIPTION
Allows using storagedevice as a trait object with ease.